### PR TITLE
Fix missing eckit_mpi.so in ECKIT_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ if( HAVE_ECKIT_CMD)
   list( APPEND ECKIT_LIBRARIES eckit_cmd )
 endif()
 
-if( HAVE_ECKIT_MPI )
+if( HAVE_MPI )
   list( APPEND ECKIT_LIBRARIES eckit_mpi )
 endif()
 


### PR DESCRIPTION
This change ensures when MPI is found that `eckit_mpi.so` exists in `ECKIT_LIBRARIES` in `${CMAKE_INSTALL_PREXFIX}/lib/cmake/eckit-config.cmake`