### PR TITLE
Bugfix/intel19 test mpi

### DIFF
--- a/tests/mpi/CMakeLists.txt
+++ b/tests/mpi/CMakeLists.txt
@@ -1,10 +1,13 @@
-ecbuild_add_test(
-    TARGET      eckit_test_mpi
-    SOURCES     eckit_test_mpi.cc
-    CONDITION   HAVE_MPI
-    LIBS eckit_mpi
-    MPI 4
-)
+
+if( NOT (CMAKE_CXX_COMPILER_ID EQUAL "Intel" AND CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 19) )
+    ecbuild_add_test(
+        TARGET      eckit_test_mpi
+        SOURCES     eckit_test_mpi.cc
+        CONDITION   HAVE_MPI 
+        LIBS eckit_mpi
+        MPI 4
+    )
+endif()
 
  ecbuild_add_test(
     TARGET      eckit_test_mpi_addcomm

--- a/tests/mpi/CMakeLists.txt
+++ b/tests/mpi/CMakeLists.txt
@@ -1,7 +1,6 @@
 #eckit_test_mpi is hanging for Intel 19.0.5. Disabling until a fix is proposed from upstream.
 if( NOT (CMAKE_CXX_COMPILER_ID STREQUAL Intel AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19
                                               AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 20) )
-    message(STATUS "CMAKE_CXX_COMPILER_ID:${CMAKE_CXX_COMPILER_ID} CMAKE_CXX_COMPILER_VERSION:${CMAKE_CXX_COMPILER_VERSION}")
     ecbuild_add_test(
         TARGET      eckit_test_mpi
         SOURCES     eckit_test_mpi.cc

--- a/tests/mpi/CMakeLists.txt
+++ b/tests/mpi/CMakeLists.txt
@@ -1,9 +1,11 @@
-
-if( NOT (CMAKE_CXX_COMPILER_ID EQUAL "Intel" AND CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 19) )
+#eckit_test_mpi is hanging for Intel 19.0.5. Disabling until a fix is proposed from upstream.
+if( NOT (CMAKE_CXX_COMPILER_ID STREQUAL Intel AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19
+                                              AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 20) )
+    message(STATUS "CMAKE_CXX_COMPILER_ID:${CMAKE_CXX_COMPILER_ID} CMAKE_CXX_COMPILER_VERSION:${CMAKE_CXX_COMPILER_VERSION}")
     ecbuild_add_test(
         TARGET      eckit_test_mpi
         SOURCES     eckit_test_mpi.cc
-        CONDITION   HAVE_MPI 
+        CONDITION   HAVE_MPI
         LIBS eckit_mpi
         MPI 4
     )


### PR DESCRIPTION
[Address jedi-stack #61](https://github.com/JCSDA/jedi-stack/issues/61) eckit_test_mpi hangs on Intel 19.0.5 builds.  Otherwise we are not seeing any issues with eckit_mpi.  Disabling that specific test for that specific compiler until upstream can address.