### PR TITLE
Extended KDNode with a public method returning the node's splitting axis

### DIFF
--- a/src/eckit/container/kdtree/KDNode.h
+++ b/src/eckit/container/kdtree/KDNode.h
@@ -45,6 +45,8 @@ public:
 
     static KDNode<Traits>* insert(Alloc& a, const Value& value, KDNode<Traits>* node, int depth = 0);
 
+    /// Return the axis along which this node is split.
+    size_t axis() const { return axis_; }
 
 public:
     void nearestNeighbourX(Alloc& a,const Point& p, Node*& best, double& max, int depth);


### PR DESCRIPTION
Addition of this method will make it possible to write custom visitors traversing a kd-tree and performing spatial queries different from the ones supported natively by the ``KDNode`` class (i.e. nearest neighbour search and retrieval of points lying in a sphere).  

I'd like to use it for queries checking whether any point in a kd-tree intersects an ellipsoid or a cylinder (https://github.com/JCSDA/oops/pull/497).
