### PR TITLE
Moved the EXPECT_EQUAL macro from oops to eckit

### DIFF
--- a/src/eckit/testing/Test.h
+++ b/src/eckit/testing/Test.h
@@ -390,6 +390,17 @@ void UNIQUE_NAME2(test_, __LINE__) (std::string& _test_subsection, int& _num_sub
         throw eckit::testing::TestException("Exception expected but was not thrown", Here()); \
     } while (false)
 
+// Consider using EXPECT_EQUAL instead of EXPECT when testing for equality of two expressions,
+// since this macro provides more informative output on failure.
+#define EXPECT_EQUAL(expr, expected) \
+    do { \
+        if (!((expr) == (expected))) { \
+            std::stringstream str; \
+            str << ("EXPECT condition '" #expr " == " #expected "' failed. ") \
+                << "(Received: " << expr << "; expected: " << expected << ")"; \
+            throw eckit::testing::TestException(str.str(), Here()); \
+        } \
+    } while (false)
 
 // Setup no longer does anything. Can be removed where it has been used
 #define SETUP(name)

--- a/tests/testing/test_testing.cc
+++ b/tests/testing/test_testing.cc
@@ -52,6 +52,7 @@ EXPECT_NOT(false);
 EXPECT_NO_THROW({ bool b = true; });
 EXPECT_THROWS(throw std::exception());
 EXPECT_THROWS_AS(throw std::exception(), std::exception);
+EXPECT_EQUAL(3, 3);
 }  // namespace test
 }  // namespace eckit
 ,
@@ -108,6 +109,25 @@ EXPECT(1 == run(fail, TestVerbosity::Silent));
 }
 ,
 
+    {CASE("EXPECT_EQUAL causes an error to be reported on failure"){
+
+       Test fail = {CASE("F"){EXPECT_EQUAL(1, 2);
+}
+}
+;
+
+std::vector<std::string> f;
+bool ret = fail.run(TestVerbosity::Silent, f);
+if (ret || f.size() == 0) {
+  throw eckit::testing::TestException("No error reported when EXPECT_EQUAL failed", Here());
+}
+if (ret || f.size() > 1) {
+  throw eckit::testing::TestException("Too many errors reported when EXPECT_EQUAL failed", Here());
+}
+}
+}
+,
+
     {CASE("EXPECT succeeds for integer comparison"){EXPECT(7 == 7);
 EXPECT(7 != 8);
 EXPECT(7 >= 6);
@@ -120,6 +140,7 @@ EXPECT_NOT(7 <= 6);
 EXPECT_NOT(7 >= 8);
 EXPECT_NOT(7 < 6);
 EXPECT_NOT(7 > 8);
+EXPECT_EQUAL(7, 7);
 }
 }
 , {CASE("Expect succeeds for integer vs. real comparison"){EXPECT(7.0 == 7);
@@ -129,6 +150,8 @@ EXPECT(7 != 8.0);
 
 EXPECT_NOT(7.0 == 8);
 EXPECT_NOT(7 != 7.0);
+
+EXPECT_EQUAL(7, 7.0);
 }
 }
 ,
@@ -149,6 +172,8 @@ EXPECT_NOT(b <= a);
 EXPECT_NOT(a >= b);
 EXPECT_NOT(b < a);
 EXPECT_NOT(a > b);
+
+EXPECT_EQUAL(a, a);
 }
 }
 ,
@@ -268,6 +293,7 @@ SECTION("Compare Collections") {
     EXPECT_NOT(a != b);
     EXPECT_NOT(a > b);
     EXPECT_NOT(a < b);
+    EXPECT_EQUAL(a, b);
     a[0] = 0;
     EXPECT_NOT(a == b);
     EXPECT_NOT(a >= b);


### PR DESCRIPTION
@srherbener In https://github.com/JCSDA/oops/pull/471#discussion_r353245084 you suggested moving the ``EXPECT_EQUAL`` macro from ``oops`` to ``eckit``. This PR, together with https://github.com/JCSDA/oops/pull/498, does that. I'm submitting them now in case you want to make these changes before the upcoming refresh of JEDI containers, but from my point of view they could equally well wait until the next time the containers are rebuilt.

I think changes would need to be made in the following order:
* merge the oops PR, which makes oops define ``EXPECT_EQUAL`` only if it doesn't find an existing definition in ``eckit``
* merge this PR
* build containers including the new version of ``eckit``
* remove the ``oops/util/Expect.h`` header (now redundant) and any references to it.

If you believe it's worth making these changes now, would you mind adding appropriate reviewers to this PR and to https://github.com/JCSDA/oops/pull/498?