### PR TITLE
revert #14

### DIFF
--- a/src/eckit/sql/sqly.y
+++ b/src/eckit/sql/sqly.y
@@ -1,7 +1,7 @@
-%define api.pure
-%lex-param {void * scanner}
+%pure-parser
+%lex-param {yyscan_t scanner}
 %lex-param {eckit::sql::SQLSession* session}
-%parse-param {void * scanner}
+%parse-param {yyscan_t scanner}
 %parse-param {eckit::sql::SQLSession* session}
 
 %{


### PR DESCRIPTION
Further testing has revealed this patch is not working on OSX systems.  As I don't understand what's wrong I will wait for upstream to address via [ecmwf/eckit #31](https://github.com/ecmwf/eckit/pull/31), and I will try disabling the SQL support for jedi-stack builds of eckit, as the current code is not portable systems with a newer version of GNU bison.