### PR TITLE
hotfix/correct #14 Fix for OSX

### DIFF
--- a/src/eckit/sql/sqly.y
+++ b/src/eckit/sql/sqly.y
@@ -1,4 +1,4 @@
-%define api.pure
+%pure-parser
 %lex-param {void * scanner}
 %lex-param {eckit::sql::SQLSession* session}
 %parse-param {void * scanner}


### PR DESCRIPTION
After submitting [ecmwf/eckit # 31](https://github.com/ecmwf/eckit/pull/31), it became apparent that OSX Bison-2.3 `yacc` was having problems with the changes as implemented in #14 .  This changes appears to fix things upstream.  Since the current release-stable is not working on OSX, this hotfix is necessary to keep things working until new upstream tagged versions are available.